### PR TITLE
Update salesforce mapping

### DIFF
--- a/example.schema.json
+++ b/example.schema.json
@@ -144,7 +144,7 @@
         "title": "Add your budget information in the rows below",
         "description": "You can add/remove/reorder rows as you desire",
         "type": "array",
-        "x-salesforceMapping": "form.budget.budgetTable",
+        "x-salesforceMapping": "form.budgetTable",
         "items": {
           "type": "object",
           "required": [
@@ -157,23 +157,23 @@
             "name": {
               "title": "Name",
               "type": "string",
-              "x-salesforceMapping": "form.budget.budgetTable.name"
+              "x-salesforceMapping": "form.budgetTable.name"
             },
             "count": {
               "title": "Number (of items)",
               "type": "integer",
-              "x-salesforceMapping": "form.budget.budgetTable.count"
+              "x-salesforceMapping": "form.budgetTable.count"
             },
             "cost": {
               "title": "Cost (per item)",
               "type": "number",
-              "x-salesforceMapping": "form.budget.budgetTable.cost"
+              "x-salesforceMapping": "form.budgetTable.cost"
             },
             "totalCost": {
               "title": "Cost (total)",
               "type": "number",
               "x-formula": "?",
-              "x-salesforceMapping": "form.budget.budgetTable.totalCost"
+              "x-salesforceMapping": "form.budgetTable.totalCost"
             }
           }
         }

--- a/example.schema.json
+++ b/example.schema.json
@@ -3,6 +3,7 @@
   "title": "react-jsonschema-form",
   "description": "An example of a form using the react-jsonschema-form extended schema",
   "type": "object",
+  "x-salesforceMapping": "Application",
   "properties": {
     "personalDetails": {
       "title": "Personal details",

--- a/example.schema.json
+++ b/example.schema.json
@@ -17,21 +17,21 @@
           "title": "Name",
           "type": "string",
           "readOnly": true,
-          "x-salesforceMapping": "form.personalDetails.name",
+          "x-salesforceMapping": "personalDetails.name",
           "x-shouldAutoComplete": true
         },
         "telephone": {
           "title": "Telephone",
           "type": "number",
           "minLength": 10,
-          "x-salesforceMapping": "form.personalDetails.telephone",
+          "x-salesforceMapping": "personalDetails.telephone",
           "x-shouldAutoComplete": true
         },
         "email": {
           "title": "Email",
           "type": "string",
           "format": "email",
-          "x-salesforceMapping": "form.personalDetails.email",
+          "x-salesforceMapping": "personalDetails.email",
           "x-shouldAutoComplete": true
         },
         "shouldShowDateOfBirth": {
@@ -45,7 +45,7 @@
             "Enter a date of birth",
             "Prefer not to say"
           ],
-          "x-salesforceMapping": "form.personalDetails.shouldShowDateOfBirth"
+          "x-salesforceMapping": "personalDetails.shouldShowDateOfBirth"
         },
         "address": {
           "title": "Address",
@@ -58,18 +58,18 @@
           "properties": {
             "buildingNameNo": {
               "title": "Building Name/Number",
-              "x-salesforceMapping": "form.personalDetails.buildingNameNo"
+              "x-salesforceMapping": "personalDetails.buildingNameNo"
             },
             "street": {
               "title": "Street",
               "type": "string",
-              "x-salesforceMapping": "form.personalDetails.street"
+              "x-salesforceMapping": "personalDetails.street"
             },
             "postcode": {
               "title": "Postcode",
               "type": "string",
               "pattern": "^[A-Z]{1,2}\d[A-Z\d]? ?\d[A-Z]{2}$",
-              "x-salesforceMapping": "form.personalDetails.postcode"
+              "x-salesforceMapping": "personalDetails.postcode"
             },
             "country": {
               "title": "Country",
@@ -87,7 +87,7 @@
                 "..."
               ],
               "x-displayAs": "typeahead",
-              "x-salesforceMapping": "form.personalDetails.country"
+              "x-salesforceMapping": "personalDetails.country"
             }
           }
         }
@@ -116,7 +116,7 @@
                   "title": "Enter your date of birth",
                   "type": "string",
                   "format": "date",
-                  "x-salesforceMapping": "form.personalDetails.dateOfBirth"
+                  "x-salesforceMapping": "personalDetails.dateOfBirth"
                 }
               },
               "required": [
@@ -138,13 +138,13 @@
         "description": "Max 200 words",
         "type": "string",
         "format": "textarea",
-        "x-salesforceMapping": "form.budget.overview"
+        "x-salesforceMapping": "budget.overview"
       },
       "budgetTable": {
         "title": "Add your budget information in the rows below",
         "description": "You can add/remove/reorder rows as you desire",
         "type": "array",
-        "x-salesforceMapping": "form.budgetTable",
+        "x-salesforceMapping": "budgetTable",
         "items": {
           "type": "object",
           "required": [
@@ -157,23 +157,23 @@
             "name": {
               "title": "Name",
               "type": "string",
-              "x-salesforceMapping": "form.budgetTable.name"
+              "x-salesforceMapping": "budgetTable.name"
             },
             "count": {
               "title": "Number (of items)",
               "type": "integer",
-              "x-salesforceMapping": "form.budgetTable.count"
+              "x-salesforceMapping": "budgetTable.count"
             },
             "cost": {
               "title": "Cost (per item)",
               "type": "number",
-              "x-salesforceMapping": "form.budgetTable.cost"
+              "x-salesforceMapping": "budgetTable.cost"
             },
             "totalCost": {
               "title": "Cost (total)",
               "type": "number",
               "x-formula": "?",
-              "x-salesforceMapping": "form.budgetTable.totalCost"
+              "x-salesforceMapping": "budgetTable.totalCost"
             }
           }
         }
@@ -188,7 +188,7 @@
         "title": "Does your proposal use animals?",
         "type": "boolean",
         "default": false,
-        "x-salesforceMapping": "form.animals.isUsingAnimals"
+        "x-salesforceMapping": "animals.isUsingAnimals"
       }
     },
     "dependencies": {
@@ -219,7 +219,7 @@
                 },
                 "uniqueItems": true,
                 "minItems": 1,
-                "x-salesforceMapping": "form.animals.typeOfAnimalUsed"
+                "x-salesforceMapping": "animals.typeOfAnimalUsed"
               }
             },
             "required": [
@@ -239,7 +239,7 @@
                         "title": "Explain why you are using these animals",
                         "type": "string",
                         "format": "textarea",
-                        "x-salesforceMapping": "form.animals.justificationForAnimals"
+                        "x-salesforceMapping": "animals.justificationForAnimals"
                       }
                     },
                     "required": [
@@ -261,7 +261,7 @@
                           "chimp"
                         ],
                         "maxItems": 1,
-                        "x-salesforceMapping": "form.animals.typesOfPrimateUsed"
+                        "x-salesforceMapping": "animals.typesOfPrimateUsed"
                       }
                     },
                     "required": [

--- a/extensions.md
+++ b/extensions.md
@@ -6,19 +6,21 @@ Below are the keywords, values and other elements the example schema uses to ext
 
 - x-shouldAutoComplete: Boolean (default: null) 
 
-This describes whether a field can be auto-completed on the front-end. Helpful for preventing auto-complete on potentially privacy-sensitive fields.  
+    This describes whether a field can be auto-completed on the front-end. Helpful for preventing auto-complete on potentially privacy-sensitive fields.  
 
 - x-salesforceMapping: String (default: “”) 
 
-This will be used to provide the middleware with the context of where the value of a form field exists in Salesforce. This could be an ID or table reference. 
+    This will be used to provide the middleware with the context of where the value of a form field exists in Salesforce. This may be defined in two places:
+    - Within the definition of a scalar value (string, number, date, etc.). In that instance the value should be of the form `TableName.FieldName`, describing which field in which table the data should be saved in.
+    - Within the definition of an array. In that instance the value should be of the form `TableName`, describing which table the array will be saved in. The `x-salesforceMapping` of items within that array should either be on the same table, or on a table that can be related back to that table.
 
 - x-renderer: String, oneOf['password', 'rte', 'textarea', 'typeahead']` (default: null) 
 
-This property is useful for describing what kind of component should render a form field, when the value does not exist natively in JSON Schema. 
+    This property is useful for describing what kind of component should render a form field, when the value does not exist natively in JSON Schema. 
 
 - enumNames: Array (default: null)  
 
-When an enum is used, this provides labels for each of the values in the enum. Taken from https: //react-jsonschema-form.readthedocs.io/en/latest/usage/single/#custom-labels-for-enum-fields 
+    When an enum is used, this provides labels for each of the values in the enum. Taken from https: //react-jsonschema-form.readthedocs.io/en/latest/usage/single/#custom-labels-for-enum-fields 
 
 ## Custom values: 
 
@@ -44,4 +46,4 @@ It’s not clear from the JSON Schema specs whether it is valid to use HTML insi
 
 ### Dependencies 
 
-This is probably the most complex piece of customisation we are proposing to the schema, so it would be good to discuss the approach we’ve proposed (above) in the example schema to get a range of opinions. 
+This is probably the most complex piece of customisation we are proposing to the schema, so it would be good to discuss the approach we’ve proposed (above) in the example schema to get a range of opinions.

--- a/extensions.md
+++ b/extensions.md
@@ -10,9 +10,11 @@ Below are the keywords, values and other elements the example schema uses to ext
 
 - x-salesforceMapping: String (default: “”) 
 
-    This will be used to provide the middleware with the context of where the value of a form field exists in Salesforce. This may be defined in two places:
-    - Within the definition of a scalar value (string, number, date, etc.). In that instance the value should be of the form `TableName.FieldName`, describing which field in which table the data should be saved in.
-    - Within the definition of an array. In that instance the value should be of the form `TableName`, describing which table the array will be saved in. The `x-salesforceMapping` of items within that array should either be on the same table, or on a table that can be related back to that table.
+    This will be used to provide the middleware with the context of where the value of a form field exists in Salesforce. It is required in three places:
+
+    - As a top-level property of the schema. In that context the value should be of the form `RootTableName`, defining the Salesforce object to which the form relates.
+    - Within the definition of an array. In that instance the value should be of the form `ArrayTableName`, describing which Salesforce object represents the array. There must be a relational mapping from `ArrayTableName` to `RootTableName`.
+    - Within the definition of a scalar value (string, number, date, etc.). In that instance the value should be of the form `ValueTableName.ValueFieldName`, defining which field in which table the data should be saved in. There must be a relational mapping from `ValueTableName` to either `RootTableName` or, if the scalar value is present in an array, `ArrayTableName`.
 
 - x-renderer: String, oneOf['password', 'rte', 'textarea', 'typeahead']` (default: null) 
 


### PR DESCRIPTION
- I've removed the `form.` prefix for `x-salesforceMapping`. While we may want namespacing eventually, for now I find it confuses things a little bit.
- I've added `x-salesforceMapping` as a top-level property, to define what is the overall table owing the form (e.g. for an application form it would be "Application", for a user profile it would be "User", etc.)
- I've changed the way the mapping work for arrays:
  - For the array element, `x-salesforceMapping` defines the Salesforce table in which each row is saved
  - Each field within the array then has it's own `x-salesforceMapping`. This can either be a field on the same table (with the table name repeated), or a field on a different table. If the field is on a different table, we must be able to relate it back to the table defined on the array element.